### PR TITLE
Remove delete filesystem

### DIFF
--- a/hooks.json
+++ b/hooks.json
@@ -1,7 +1,7 @@
 {
     "configuration":
     {
-        "delete": true,
+        "delete": false,
         "desktop_ready_delay": 90
     },
     "hooks":

--- a/hooks.json
+++ b/hooks.json
@@ -2,6 +2,7 @@
     "configuration":
     {
         "delete": false,
+        "replace": true,
         "desktop_ready_delay": 90
     },
     "hooks":

--- a/hooks.json
+++ b/hooks.json
@@ -13,7 +13,6 @@
             "name": "hooks.filesystem.FilesystemHook",
             "configuration":
             {
-                "delete": true,
                 "enumerate": true,
                 "log_progress": true,
                 "log_progress_delay": 10,

--- a/hooks/filesystem.py
+++ b/hooks/filesystem.py
@@ -52,7 +52,6 @@ class FilesystemHook(Hook):
         super().__init__(parameters)
         # config
         self.graph = self.configuration['graph']
-        self.delete = self.configuration.get('delete', False)
         self.enumerate = self.configuration.get('enumerate', False)
         self.log_progress = self.configuration.get('log_progress', True)
         self.log_progress_delay = int(self.configuration.get('log_progress_delay', 0))
@@ -68,10 +67,6 @@ class FilesystemHook(Hook):
 
     def capture_fs(self, event):
         with guestfs_instance(self) as gfs:
-            # delete previous graph ?
-            if self.delete:
-                self.logger.info('Delete all nodes in graph')
-                self.graph.delete_all()
             root = Path('/')
             if self.enumerate:
                 self.logger.info('Enumerating entries')


### PR DESCRIPTION
The filesystem hook shouldn't have to delete the whole graph.

This was a legacy key for development purposes.

Also changed the default hooks.json, so that it doesn't erase the database in the default config, and replaces any existing OS in the database

cc @nettrino

