### PR TITLE
lock python-see to 1.2.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 docopt
 libvirt-python
 py2neo
-python-see
+python-see==1.2.8
 seaborn


### PR DESCRIPTION
This locks python-see to 1.2.8 release because of regressions in the newer releases.

related https://github.com/F-Secure/see/issues/59