### PR TITLE
Filesystem: use libmagic bindings

### DIFF
--- a/hooks/filesystem.py
+++ b/hooks/filesystem.py
@@ -14,6 +14,7 @@ from oswatcher.model import GraphInode
 
 # 3rd
 import guestfs
+import magic
 from see import Hook
 from git import Repo
 
@@ -165,7 +166,7 @@ class FilesystemHook(Hook):
         filepath = event.filepath
         inode = event.inode
         # determine MIME type
-        mime_type = subprocess.check_output(['file', '-bi', filepath]).decode().rstrip()
+        mime_type = magic.from_file(filepath, mime=True)
         self.context.trigger('filesystem_new_file_mime', filepath=filepath, inode=inode, mime=mime_type)
 
     def update_log(self, node):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ py2neo
 python-see==1.3.0
 seaborn
 GitPython==3.0.5
+python-magic==0.4.15


### PR DESCRIPTION
use libmagic instead of `file` command, avoids useless process creation