### PR TITLE
add setup.py to install oswatcher as command line tool

### DIFF
--- a/.github/workflows/capture_filesystem.yml
+++ b/.github/workflows/capture_filesystem.yml
@@ -31,8 +31,8 @@ jobs:
     - name: Install OSWatcher pip dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install docopt lxml
+        pip install .
+        pip install lxml
         pip install http://download.libguestfs.org/python/guestfs-1.40.2.tar.gz
     - name: Download import_libvirt script
       run: |

--- a/.github/workflows/capture_processes.yml
+++ b/.github/workflows/capture_processes.yml
@@ -31,8 +31,8 @@ jobs:
     - name: Install OSWatcher pip dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install docopt lxml
+        pip install .
+        pip install lxml
         pip install http://download.libguestfs.org/python/guestfs-1.40.2.tar.gz
     - name: Install Volatility from git
       run: |

--- a/.github/workflows/capture_syscalls.yml
+++ b/.github/workflows/capture_syscalls.yml
@@ -31,8 +31,8 @@ jobs:
     - name: Install OSWatcher pip dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install docopt lxml
+        pip install .
+        pip install lxml
         pip install http://download.libguestfs.org/python/guestfs-1.40.2.tar.gz
     - name: Install Volatility from git
       run: |

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ sudo apt-get install virtualenv python3-virtualenv libguestfs0 libguestfs-dev py
 ~~~
 virtualenv --system-site-packages -p python3 venv
 source venv/bin/activate
-pip install -r requirements.txt
+pip install .
 ~~~
 
 Note: We have to use `--system-site-packages` because `libguestfs` is not

--- a/oswatcher/__main__.py
+++ b/oswatcher/__main__.py
@@ -14,9 +14,14 @@ import sys
 
 from docopt import docopt
 
-from .capture import main
+from .capture import capture_main
 
 
-args = docopt(__doc__)
-retcode = main(args)
-sys.exit(retcode)
+def main():
+    args = docopt(__doc__)
+    retcode = capture_main(args)
+    sys.exit(retcode)
+
+
+if __name__ == "__main__":
+    main()

--- a/oswatcher/capture.py
+++ b/oswatcher/capture.py
@@ -113,7 +113,7 @@ def init_logger(debug=False):
     logging.getLogger("git.repo").setLevel(logging.WARNING)
 
 
-def main(args):
+def capture_main(args):
     vm_name = args['<vm_name>']
     uri = args['--connection']
     debug = args['--debug']

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,31 @@
+import setuptools
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+with open('requirements.txt') as f:
+    requirements = f.read().splitlines()
+
+setuptools.setup(
+    name="oswatcher",
+    version="0.0.1",
+    author="Mathieu Tarral",
+    author_email="mathieu.tarral@protonmail.com",
+    description="A tool to capture and extract information from an operating system",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/Wenzel/oswatcher",
+    packages=setuptools.find_packages(),
+    install_requires=requirements,
+    entry_points = {
+        'console_scripts': [
+            'oswatcher = oswatcher.__main__:main'
+        ],
+    },
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+        "Operating System :: POSIX :: Linux",
+    ],
+    python_requires='>=3.7',
+)


### PR DESCRIPTION
@milenkowski this PR allows OSWatcher to be installed as a command line tool, via `setup.py`

~~~
virtualenv --system-site-packages -p python3 venv
source venv/bin/activate
pip install .
~~~