### PR TITLE
requirements: upgrade GitPython to avoid dependency error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ libvirt-python
 py2neo
 python-see==1.3.0
 seaborn
-GitPython==3.0.5
+GitPython==3.1.0
 python-magic==0.4.15


### PR DESCRIPTION
Fix `ModuleNotFound` when loading `GitPython`

Related: https://github.com/gitpython-developers/GitPython/issues/983